### PR TITLE
refactor gradle build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 100
+    reviewers:
+      - planetf1
+      - davidradl
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 25
+    reviewers:
+      - planetf1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,34 +40,34 @@ jobs:
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+          queries: security-and-quality
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # - run: |
+      #   make bootstrap
+      #   make release
 
-    #- run: |
-    #   make bootstrap
-    #   make release
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,10 +36,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [  ]
+        language: [ 'java' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, * ]
+    branches:
+      - main
+      - release.*
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches:
+      - main
+      - release.*
   schedule:
     - cron: '20 23 * * 6'
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+name: "Merge"
+
+on:
+  push:
+    branches: [main, release-*, feature-*]
+  # Also allow for manual invocation for testing
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Merge"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'temurin'
+      # Only for a merge into this repo - not a fork, and just for the main branch
+      - name: Build (Publish snapshots to maven central)
+        if: ${{ github.repository == 'odpi/egeria-integration-topic-strimzi' && github.ref == 'refs/heads/main'}}
+        # TODO: Need to extend build to make use of snapshot repo for publishing
+        run: ./gradlew publish
+        # Import secrets needed for code signing and distribution
+        env:
+          OSSRH_GPG_KEYID: ${{ secrets.OSSRH_GPG_KEYID }}
+          OSSRH_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+          OSSRH_GPG_PRIVATE_KEY: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      # In other cases just build but don't publish
+      - name: Build (no snapshots)
+        if: ${{ github.repository != 'odpi/egeregeria-integration-topic-strimzi' || github.ref != 'refs/heads/main'}}
+        run: ./gradlew build
+      # --
+      - name: Upload Connector
+        uses: actions/upload-artifact@v2
+        with:
+          name: Postgres Connector
+          path: '**/build/libs/*.jar'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+---
+name: "Release"
+
+# Trigger after code is merged. only on main repo
+# - does not run on modification (may be just text)
+on:
+  # No checks for branch or repo - assuming release creation is manual, controlled
+  release:
+    types:
+      - created
+  # Also allow for manual invocation for testing
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Release"
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout source
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Build with Gradle & Release artifacts
+        # TODO: Need to extend build to make use of release repo for publishing
+        run: ./gradlew publish
+        # Import secrets needed for code signing and distribution
+        env:
+          OSSRH_GPG_KEYID: ${{ secrets.OSSRH_GPG_KEYID }}
+          OSSRH_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
+          OSSRH_GPG_PRIVATE_KEY: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      # Upload the library so that build results can be viewed
+      - name: Upload Connector
+        uses: actions/upload-artifact@v2
+        with:
+          name: Postgres Connector
+          path: '**/build/libs/*.jar'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+---
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check stale issues and prs
+        if: startsWith(github.repository,'odpi/')
+        uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            not had recent activity. It will be closed in 20 days if no
+            further activity occurs. Thank you for your contributions.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 20 days if no further
+            activity occurs. Thank you for your contributions.
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          days-before-stale: 60
+          days-before-close: 20
+          exempt-issue-label: 'pinned'
+          exempt-pr-label: 'pinned'
+          operations-per-run: 30

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+name: "PR Verification"
+
+on:
+  pull_request:
+    branches: [main, release-*, feature-*]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "PR Verification"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'temurin'
+      - name: Build
+        run: ./gradlew build
+      # --
+      - name: Upload Connector
+        uses: actions/upload-artifact@v2
+        with:
+          name: Postgres Connector
+          path: '**/build/libs/*.jar'

--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,25 @@ plugins {
     id 'java-library'
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id 'idea'
+    id 'maven-publish'
+}
+
+if (System.getenv("CI")) {
+    apply plugin: 'signing'
 }
 
 repositories {
     mavenCentral()
+    maven { url("https://oss.sonatype.org/content/repositories/snapshots") }
+    mavenLocal() // note - this may pick up modified classes from ~/.m2
 }
+
+// ensures we pick up the very latest snapshots when built
+configurations.all {
+    // check for updates every build
+    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+}
+
 group = 'org.odpi.egeria'
 version = 1
 
@@ -69,7 +83,10 @@ test {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+    withJavadocJar()
+    withSourcesJar()
 }
+
 // More Java language settings
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
@@ -81,7 +98,89 @@ tasks.withType(JavaCompile) {
     options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'
 }
 
+// For later java versions this is recommended - keep conditional in case we want to build on 8
+javadoc {
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}
+
 shadowJar {
     archiveClassifier = 'jar-with-dependencies'
 }
 
+// We only have a single artifact for now - this additional metadata is
+// required for publishing to maven central. Only doing signing in 'CI'
+publishing {
+    publications {
+        connector(MavenPublication) {
+            from components.java
+            pom {
+                url = 'http://egeria.odpi.org'
+                licenses {
+                    // Code
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                    // Docs
+                    license {
+                        name = 'Creative Commons Attribution 4.0 International (CC BY 4.0)'
+                        url = 'https://creativecommons.org/licenses/by/4.0'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'planetf1'
+                        name = 'Nigel Jones'
+                        email = 'nigel.l.jones+git@gmail.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git://github.com/odpi/egeria-integration-connector-strimzi.git'
+                    developerConnection = 'scm:git:ssh://github.com/odpi/egeria/egeria-integration-connector-strimzi.git'
+                    url = 'http://github.com/odpi/egeria-integration-connector-strimzi/'
+                }
+            }
+            // Override the project name & description for the pom based on properties set in the child build.gradle (hard to default & required for maven central)
+            pom.withXml {
+                asNode().appendNode('name', "${project.ext.name}")
+                asNode().appendNode('description', "${project.description}")
+            }
+        }
+    }
+
+    // Release versions get pushed to staging area on maven central, snapshots to snapshot repo
+    // Secrets for credentials
+    if (System.getenv("CI")) {
+        repositories {
+            maven {
+                name = 'OSSRH'
+                def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+                def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                // User token (under profile) on oss.sonatype.org
+                credentials {
+                    username = System.getenv("OSSRH_USERNAME")
+                    password = System.getenv("OSSRH_TOKEN")
+                }
+            }
+        }
+    }
+}
+
+// To publish to ossrh we need to sign the artifacts - only in CI
+if (System.getenv("CI")) {
+    signing {
+        // This is the publication to sign
+        sign publishing.publications.connector
+        // gpg --export-secret-keys myemal@gmail.com | base64
+        def signingKey = System.getenv("OSSRH_GPG_PRIVATE_KEY")
+        // Passphrase for key
+        def signingPassword = System.getenv("OSSRH_GPG_PASSPHRASE")
+        // public key id (last 8 characters only) - note keys also need uploading to all the main registries
+        def signingKeyId = System.getenv("OSSRH_GPG_KEYID")
+        // We use these values from secrets rather than gradle.properties
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ configurations.all {
 }
 
 group = 'org.odpi.egeria'
-version = 1
+version = '1.0'
 
 ext {
     egeriaversion = '3.6'

--- a/build.gradle
+++ b/build.gradle
@@ -3,50 +3,61 @@
  * Copyright Contributors to the ODPi Egeria project.
  */
 
+plugins {
+    id 'java-library'
+    id "com.github.johnrengelman.shadow" version "7.1.2"
+    id 'idea'
+}
+
 repositories {
-        mavenCentral()
+    mavenCentral()
 }
 group = 'org.odpi.egeria'
 version = 1
-configurations {
-    extralibs
-}
-apply plugin: 'java-library'
+
 ext {
-    egeriaversion = '3.2'
-    logbackVersion = '1.2.6'
-    jacksonVersion = '2.13.0'
-    junitjupiterVersion = '5.8.1'
+    egeriaversion = '3.6'
+    slf4jVersion = '1.7.36'
+    jacksonVersion = '2.13.2'
+    jupiterVersion = '5.8.2'
+    httpclientVersion = '4.5.13'
 }
 dependencies {
-        implementation "org.slf4j:slf4j-api:${logbackVersion}"
-        implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-        implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
-        implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-        implementation "org.junit.jupiter:junit-jupiter:${junitjupiterVersion}"
-        implementation "org.odpi.egeria:open-connector-framework:${egeriaversion}"
-        implementation "org.odpi.egeria:audit-log-framework:${egeriaversion}"
-        implementation "org.odpi.egeria:repository-services:${egeriaversion}"
-        implementation "org.odpi.egeria:repository-services-apis:${egeriaversion}"
-        implementation "org.odpi.egeria:topic-integrator-api:${egeriaversion}"
-        implementation "org.odpi.egeria:kafka-open-metadata-topic-connector:${egeriaversion}"
-        extralibs 'org.apache.httpcomponents:httpclient:4.5.13'
-        configurations.compile.extendsFrom(configurations.extralibs)
+
+    // Only used for build - already present in server chassis at runtime
+    compileOnly "org.odpi.egeria:audit-log-framework:${egeriaversion}"
+    compileOnly "org.odpi.egeria:data-manager-api:${egeriaversion}"
+    // TODO: this is a dependency on an optional connector. validate, document as needed, consider packaging impact
+
+    compileOnly "org.odpi.egeria:kafka-open-metadata-topic-connector:${egeriaversion}"
+    compileOnly "org.odpi.egeria:open-connector-framework:${egeriaversion}"
+    compileOnly "org.odpi.egeria:repository-services-apis:${egeriaversion}"
+    compileOnly "org.odpi.egeria:repository-services:${egeriaversion}"
+    compileOnly "org.odpi.egeria:topic-integrator-api:${egeriaversion}"
+
+    // Needed for build and run
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "org.apache.httpcomponents:httpclient:${httpclientVersion}"
+    implementation "org.slf4j:slf4j-api:${slf4jVersion}"
+
+    // Only needed to compile test code
+    testCompileOnly "org.junit.jupiter:junit-jupiter-api:${jupiterVersion}"
+    testImplementation "org.odpi.egeria:topic-integrator-api:${egeriaversion}"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}"
+
+    // TODO: Refactor above with custom configurations if cleaner
 }
+
 
 test {
     useJUnitPlatform()
-    dependencies {
-        testCompile("org.junit.jupiter:junit-jupiter-api:5.7.0")
-        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.7.0"
-        testImplementation "org.junit.jupiter:junit-jupiter-params:5.7.0"
-        testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
-    }
     testLogging {
         events "passed", "skipped", "failed"
     }
     reports {
-        html.enabled = true
+        html.required = true
     }
     filter {
         includeTestsMatching "*Test"
@@ -70,9 +81,7 @@ tasks.withType(JavaCompile) {
     options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'
 }
 
-jar {
-    from {
-        configurations.extralibs.filter{it.exists()}
-        .collect{it.isDirectory() ? it : zipTree(it)}
-    }
+shadowJar {
+    archiveClassifier = 'jar-with-dependencies'
 }
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the ODPi Egeria project.
+
+# Allow parallel builds (defaults will be 1 per CPU thread)
+org.gradle.parallel=true
+
+# Caching
+org.gradle.caching=false
+
+# Watch fileystem - disable - too many files swamps OS
+org.gradle.vfs.watch=false
+
+# Default logging output
+org.gradle.console=auto
+
+# Stop if we get a warning
+org.gradle.warning.mode=summary
+
+# Defer configuration until needed
+org.gradle.configureondemand=true
+
+# Increase memory to 4GB
+org.gradle.jvmargs=-Xmx4096m
+
+# If system is quiet, all cpu will be used anyway. But on interactive desktop this will
+# help keep system responsive whilst a build is running
+org.gradle.priority=low
+
+# Timeout the daemon after an hour
+org.gradle.daemon.idletimeout=3600000

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Refactoring changes to gradle build
 - migrates syntax for plugins & reports to current gradle & updates gradle version
 - adds shadow plugin for building jar with dependencies (note new name)
 - adds idea plugin (helps IntelliJ users)
 - updates dependency versions to current
 - ensures all dependencies use properties
 - flattens dependencies (for now)
 - adds gradle properties as used on core egeria
 - added maven publishing & signing (credentials lookup, config values for pom.xml, plugins & tasks)
 - added snapshot repo 
 - added javadoc+config & sources jar (required by maven central rules)
 
 Note: Not tested connector resolves required classes at runtime