### PR TITLE
Update version to snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ configurations.all {
 }
 
 group = 'org.odpi.egeria'
-version = '1.0'
+version = '1.0-SNAPSHOT'
 
 ext.name = 'Strimzi topic integration connector'
 description = 'Strimzi topic integration connector for Egeria'


### PR DESCRIPTION
Our development releases built off master need to be a -SNAPSHOT release 
to publish correctly to the snapshot repository

Updating version to 1.0-SNAPSHOT