### PR TITLE
Update artifact name to follow egeria naming pattern for connectors

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,5 +13,5 @@ pluginManagement {
         //id 'maven-publish' version
     }
 }
-rootProject.name = 'egeria-integration-connector-strimzi'
+rootProject.name = 'egeria-connector-integration-topic-strimzi'
 


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Corrected maven artifact name to org.odpi.egeria:egeria-connector-integration-topic-strimzi
 - previously connector/integration were reversed & topic was missing
 - also matches the repo name