### PR TITLE
Add Docker build support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,12 @@ updates:
     open-pull-requests-limit: 25
     reviewers:
       - planetf1
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "03:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    reviewers:
+      - planetf1

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Contributors to the ODPi Egeria project.
+# Copyright Contributors to the Egeria project.
 name: "Merge"
 
 on:
@@ -8,10 +8,9 @@ on:
   # Also allow for manual invocation for testing
   workflow_dispatch:
 
-
 jobs:
   build:
-    if: ${{ github.repository == 'odpi/egeria-connector-integration-topic-strimzi'}}
+    if: startsWith(github.repository,'odpi/')
     runs-on: ubuntu-latest
     name: "Merge"
     steps:
@@ -24,10 +23,12 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       # Only for a merge into this repo - not a fork, and just for the main branch
       - name: Build (Publish snapshots to maven central)
-        if: ${{ github.repository == 'odpi/egeria-connector-integration-topic-strimzi' && github.ref == 'refs/heads/main'}}
-        # TODO: Need to extend build to make use of snapshot repo for publishing
-        run: ./gradlew publish
-        # Import secrets needed for code signing and distribution
+        if: ${{ github.ref == 'refs/heads/main'}}
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
+          arguments: build publish
+          # Import secrets needed for code signing and distribution
         env:
           OSSRH_GPG_KEYID: ${{ secrets.OSSRH_GPG_KEYID }}
           OSSRH_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
@@ -36,11 +37,53 @@ jobs:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       # In other cases just build but don't publish
       - name: Build (no snapshots)
-        if: ${{ github.repository != 'odpi/egeria-connector-integration-topic-strimzi' || github.ref != 'refs/heads/main'}}
-        run: ./gradlew build
+        if: ${{ github.ref != 'refs/heads/main' }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
+          arguments: build
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to container registry (Quay.io)
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_ACCESS_TOKEN }}
+      - name: Login to container registry (Docker Hub)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # QEMU is needed for ARM64 build for egeria-configure
+      # egeria-configure needs to install utilities
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set Release version env variables
+        run: |
+          echo "VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
+          echo "EGERIA_BASE_IMAGE=quay.io/odpi/egeria:$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)" >> $GITHUB_ENV
+      - name: Build and push to quay.io and docker.io (tag latest only for main!)
+        if: ${{ github.ref == 'refs/heads/main'}}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: odpi/egeria:${{ env.VERSION }}, odpi/egeria:latest, quay.io/odpi/egeria-connector-integration-topic-strimzi:${{ env.VERSION }}, quay.io/odpi/egeria-connector-integration-topic-strimzi:latest
+          platforms: linux/amd64,linux/arm64
+      - name: Build and push( to quay.io and docker.io (no tag latest)
+        if: ${{ github.ref != 'refs/heads/main'}}
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: odpi/egeria:${{ env.VERSION }}, quay.io/odpi/egeria-connector-integration-topic-strimzi:${{ env.VERSION }}
+          platforms: linux/amd64,linux/arm64
       # --
       - name: Upload Connector
         uses: actions/upload-artifact@v3
         with:
-          name: Strimzi Integration Connector
+          # TODO: merge - Update name & artifacts to upload
+          name: Jar
           path: '**/build/libs/*.jar'
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright Contributors to the ODPi Egeria project.
+# Copyright Contributors to the Egeria project.
 ---
 name: "Release"
 
@@ -27,18 +27,47 @@ jobs:
           java-version: '11'
       - uses: gradle/wrapper-validation-action@v1
       - name: Build with Gradle & Release artifacts
-        # TODO: Need to extend build to make use of release repo for publishing
-        run: ./gradlew publish
-        # Import secrets needed for code signing and distribution
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
+          arguments:  publish        # Import secrets needed for code signing and distribution
         env:
           OSSRH_GPG_KEYID: ${{ secrets.OSSRH_GPG_KEYID }}
           OSSRH_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_PASSPHRASE }}
           OSSRH_GPG_PRIVATE_KEY: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+
+      - name: Login to container registry (Quay.io)
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_IO_USERNAME }}
+          password: ${{ secrets.QUAY_IO_ACCESS_TOKEN }}
+      - name: Login to container registry (Docker Hub)
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      # QEMU is needed for ARM64 build for egeria-configure
+      # egeria-configure needs to install utilities
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set Release version env variable
+        run: |
+          echo "VERSION=$(./gradlew properties --no-daemon --console=plain -q | grep '^version:' | awk '{printf $2}')" >> $GITHUB_ENV
+          echo "EGERIA_BASE_IMAGE=quay.io/odpi/egeria:$(./gradlew dependencies | grep org.odpi.egeria:open-connector-framework | awk -F':' '{print $3}' | awk -F' ' '{print $1}' | uniq| head -1)" >> $GITHUB_ENV
+      - name: Build and push( to quay.io and docker.io (no tag latest)
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: odpi/egeria:${{ env.VERSION }}, quay.io/odpi/egeria-connector-integration-topic-strimzi:${{ env.VERSION }}
+          platforms: linux/amd64,linux/arm64
       # Upload the library so that build results can be viewed
       - name: Upload Connector
         uses: actions/upload-artifact@v3
         with:
-          name: Strimzi Integration Connector
+          # TODO: release - Update name & artifacts to upload
+          name: Jar
           path: '**/build/libs/*.jar'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,16 @@
-# NOTE: this Dockerfile is not used by the CI pipeline
-# on openshift because we want to add multiple projects
-# to the same image later.
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Contributors to the Egeria project
 
-FROM quay.io/ibmgaragecloud/gradle:jdk11 as build
+# This is the EGERIA version - typically passed from the ci/cd pipeline
+ARG EGERIA_BASE_IMAGE=quay.io/odpi/egeria:latest
 
-# Copy files
-COPY gradle gradle
-COPY settings.gradle .
-COPY gradlew .
-COPY build.gradle .
-COPY src src
+FROM ${EGERIA_BASE_IMAGE}
 
-# Build application and test it
-RUN ./gradlew assemble --no-daemon && \
-    ./gradlew testClasses --no-daemon
+# Labels from https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys (with additions prefixed    ext)
+# We should inherit all the base labels from the egeria image and only overwrite what is necessary.
+LABEL org.opencontainers.image.description = "Egeria with Strimzi connector" \
+      org.opencontainers.image.documentation = "https://github.com/odpi/egeria-connector-integration-topic-strimzi"
 
-# Get Egeria base image and add build artifacts
-FROM quay.io/odpi/egeria:latest
-COPY --from=build /home/gradle/build /strimzi/build
+# This assumes we only have one uber jar (ensure old versions cleaned out beforehand). Avoids having to pass connector version
+COPY build/libs/egeria-connector-integration-topic-strimzi-*-with-dependencies.jar /deployments/server/lib
+

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,22 @@
+# NOTE: this Dockerfile is not used by the CI pipeline
+# on openshift because we want to add multiple projects
+# to the same image later.
+
+# See Dockerfile in the same directory for the container build process used by the Egeria opensource project
+
+FROM quay.io/ibmgaragecloud/gradle:jdk11 as build
+
+# Copy files
+COPY gradle gradle
+COPY settings.gradle .
+COPY gradlew .
+COPY build.gradle .
+COPY src src
+
+# Build application and test it
+RUN ./gradlew assemble --no-daemon && \
+    ./gradlew testClasses --no-daemon
+
+# Get Egeria base image and add build artifacts
+FROM quay.io/odpi/egeria:latest
+COPY --from=build /home/gradle/build /strimzi/build

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Add standard Dockerfile to create an egeria base image including connector. Version of egeria is based on dependencies in gradle build file
* Renamed existing Dockerfile - that is not being used in opensource ci/cd & is used to build connector from source
* Updated gradle to current version
* Added dependabot support for docker 

NOTE: No changes made to dependencies of this connector
-> XX This is still being built with 3.10
-> XX Other old dependencies still need fixing (see open PRs)
-> XX The core egeria 'platform' should be added to provide dependency constraints
cc: @davidradl @juergenhemelt 